### PR TITLE
Adjust tourism strong link boosts

### DIFF
--- a/src/economy-model2.ts
+++ b/src/economy-model2.ts
@@ -465,7 +465,7 @@ export const applyStrongLinkBoost = (inf: Economy, map: EconomyMap, site: SiteMa
       return;
 
     case 'tourism':
-      if (useNewModel) { // disable for now
+      if (useNewModel) {
         if (matches([BT.aw, BT.elw, BT.ww], site.body?.type)) {
           adjust(inf, +0.4, `+ ${reason} boost: Body is AW/ELW/WW`, map, site, 'body');
         }


### PR DESCRIPTION
Strong link boosts from ELW/WW/AW, bio signals, geo signals, BH presence, NS presence, WD presence, all stack with one another.

Before change:
<img width="1662" height="1373" alt="image" src="https://github.com/user-attachments/assets/a5abdb9e-030a-4c14-8b81-4574c4591280" />

After change:
<img width="1665" height="1356" alt="image" src="https://github.com/user-attachments/assets/11c27b65-e849-4596-b238-22a8c0c405e4" />

[Spansh economy %s:](https://spansh.co.uk/station/4269509635)
<img width="1408" height="640" alt="image" src="https://github.com/user-attachments/assets/c37cfc48-5191-478d-b54d-9d5fdf4f066d" />
