### PR TITLE
Prevent securing a system until a completed site has a marketId

### DIFF
--- a/src/views/SystemView2/SystemCard.tsx
+++ b/src/views/SystemView2/SystemCard.tsx
@@ -19,7 +19,7 @@ export const SystemCard: FunctionComponent<{ targetId: string, sysView: SystemVi
   // const [editors, setEditors] = useState<Set<string>>(new Set<string>(sysMap.editors));
 
   const hasCompleteSite = sysMap.sites.some(s => s.status === 'complete' && s.marketId);
-  const isOpen = !hasCompleteSite || sysMap.open;
+  const isOpen = hasCompleteSite && sysMap.open;
 
   const hasArchitect = !!props.sysView.state.sysOriginal.architect;
   const isArchitect = hasArchitect && isMatchingCmdr(props.sysView.state.sysOriginal.architect, store.cmdrName);
@@ -192,7 +192,7 @@ export const SystemCard: FunctionComponent<{ targetId: string, sysView: SystemVi
               text={isOpen ? 'Open' : 'Secured'}
               title='Only architects with a completed, linked site can Secure exclusive edit access'
               disabled={!canEditAsArchitect || !hasCompleteSite}
-              style={{ textDecoration: !hasArchitect && !isOpen ? 'line-through 1px' : undefined }}
+              style={{ textDecoration: (!hasCompleteSite || !hasArchitect) && !isOpen ? 'line-through 1px' : undefined }}
               onClick={() => {
                 props.sysView.updateOpen(!sysMap.open);
               }}

--- a/src/views/SystemView2/SystemCard.tsx
+++ b/src/views/SystemView2/SystemCard.tsx
@@ -190,7 +190,7 @@ export const SystemCard: FunctionComponent<{ targetId: string, sysView: SystemVi
               className={cn.bBox}
               iconProps={{ iconName: isOpen ? 'Unlock' : 'LockSolid', style: { fontSize: 12 } }}
               text={isOpen ? 'Open' : 'Secured'}
-              title={!hasCompleteSite ? 'Complete your 1st site to secure this system' : 'Only architects can edit a secured system'}
+              title='Only architects with a completed, linked site can Secure exclusive edit access'
               disabled={!canEditAsArchitect || !hasCompleteSite}
               style={{ textDecoration: !hasArchitect && !isOpen ? 'line-through 1px' : undefined }}
               onClick={() => {

--- a/src/views/SystemView2/SystemCard.tsx
+++ b/src/views/SystemView2/SystemCard.tsx
@@ -22,6 +22,7 @@ export const SystemCard: FunctionComponent<{ targetId: string, sysView: SystemVi
 
   const hasArchitect = !!props.sysView.state.sysOriginal.architect;
   const isArchitect = hasArchitect && isMatchingCmdr(props.sysView.state.sysOriginal.architect, store.cmdrName);
+  const hasCompleteSite = sysMap.sites.some(s => s.status === 'complete' && s.marketId);
   // const couldEditAsArchitect = props.sysView.state.sysOriginal.open || !props.sysView.state.sysOriginal.architect || isArchitect;
   // const aboutToLock = couldEditAsArchitect && !props.sysView.state.sysMap.open && !!props.sysView.state.sysMap?.architect && !isMatchingCmdr(props.sysView.state.sysMap?.architect, store.cmdrName);
   return <div>
@@ -93,6 +94,7 @@ export const SystemCard: FunctionComponent<{ targetId: string, sysView: SystemVi
             {canEditAsArchitect && <ViewEditName
               name={sysMap.architect || '?'}
               prefix='Cmdr '
+              disabled={!hasCompleteSite}
               onChange={newName => {
                 sysMap.architect = newName;
                 props.sysView.setState({ sysMap: sysMap });
@@ -103,15 +105,23 @@ export const SystemCard: FunctionComponent<{ targetId: string, sysView: SystemVi
               className={cn.bBox}
               iconProps={{ iconName: 'AddFriend', style: { fontSize: 12 } }}
               text={'I am the architect'}
-              title='Claim this system for yourself'
-              disabled={!canEditAsArchitect}
+              title={hasCompleteSite ? 'Claim this system for yourself' : 'Complete your 1st site to claim Architect'}
+              disabled={!canEditAsArchitect || !hasCompleteSite}
               onClick={() => {
                 sysMap.architect = store.cmdrName;
                 props.sysView.setState({ sysMap: sysMap });
               }}
             />}
+          </Stack>
 
-            {/* {isArchitect && <IconButton
+          {!hasCompleteSite && !sysMap.architect && <>
+            <div />
+            <div style={{ color: appTheme.palette.themeTertiary, fontSize: 12, gridColumn: '2' }}>
+              Complete your 1st site to claim Architect
+            </div>
+          </>}
+
+          {/* {isArchitect && <IconButton
               className={cn.bBox}
               iconProps={{ iconName: 'AddFriend', style: { fontSize: 12 } }}
               text={'Add someone?'}
@@ -120,7 +130,6 @@ export const SystemCard: FunctionComponent<{ targetId: string, sysView: SystemVi
               style={{ textDecoration: !hasArchitect ? 'line-through 2px' : undefined, float: 'right' }}
               onClick={() => setNewEditor(" ")}
             />} */}
-          </Stack>
 
           {/* {(!!newEditor || editors.size > 0) && <>
             <div style={{ alignContent: 'start' }}>Editors:</div>

--- a/src/views/SystemView2/SystemCard.tsx
+++ b/src/views/SystemView2/SystemCard.tsx
@@ -18,11 +18,11 @@ export const SystemCard: FunctionComponent<{ targetId: string, sysView: SystemVi
   // const [newEditor, setNewEditor] = useState<string | undefined>();
   // const [editors, setEditors] = useState<Set<string>>(new Set<string>(sysMap.editors));
 
-  const isOpen = sysMap.open;
+  const hasCompleteSite = sysMap.sites.some(s => s.status === 'complete' && s.marketId);
+  const isOpen = !hasCompleteSite || sysMap.open;
 
   const hasArchitect = !!props.sysView.state.sysOriginal.architect;
   const isArchitect = hasArchitect && isMatchingCmdr(props.sysView.state.sysOriginal.architect, store.cmdrName);
-  const hasCompleteSite = sysMap.sites.some(s => s.status === 'complete' && s.marketId);
   // const couldEditAsArchitect = props.sysView.state.sysOriginal.open || !props.sysView.state.sysOriginal.architect || isArchitect;
   // const aboutToLock = couldEditAsArchitect && !props.sysView.state.sysMap.open && !!props.sysView.state.sysMap?.architect && !isMatchingCmdr(props.sysView.state.sysMap?.architect, store.cmdrName);
   return <div>
@@ -94,7 +94,6 @@ export const SystemCard: FunctionComponent<{ targetId: string, sysView: SystemVi
             {canEditAsArchitect && <ViewEditName
               name={sysMap.architect || '?'}
               prefix='Cmdr '
-              disabled={!hasCompleteSite}
               onChange={newName => {
                 sysMap.architect = newName;
                 props.sysView.setState({ sysMap: sysMap });
@@ -105,21 +104,14 @@ export const SystemCard: FunctionComponent<{ targetId: string, sysView: SystemVi
               className={cn.bBox}
               iconProps={{ iconName: 'AddFriend', style: { fontSize: 12 } }}
               text={'I am the architect'}
-              title={hasCompleteSite ? 'Claim this system for yourself' : 'Complete your 1st site to claim Architect'}
-              disabled={!canEditAsArchitect || !hasCompleteSite}
+              title='Claim this system for yourself'
+              disabled={!canEditAsArchitect}
               onClick={() => {
                 sysMap.architect = store.cmdrName;
                 props.sysView.setState({ sysMap: sysMap });
               }}
             />}
           </Stack>
-
-          {!hasCompleteSite && !sysMap.architect && <>
-            <div />
-            <div style={{ color: appTheme.palette.themeTertiary, fontSize: 12, gridColumn: '2' }}>
-              Complete your 1st site to claim Architect
-            </div>
-          </>}
 
           {/* {isArchitect && <IconButton
               className={cn.bBox}
@@ -198,13 +190,16 @@ export const SystemCard: FunctionComponent<{ targetId: string, sysView: SystemVi
               className={cn.bBox}
               iconProps={{ iconName: isOpen ? 'Unlock' : 'LockSolid', style: { fontSize: 12 } }}
               text={isOpen ? 'Open' : 'Secured'}
-              title='Only architects can edit a secured system'
-              disabled={!canEditAsArchitect}
+              title={!hasCompleteSite ? 'Complete your 1st site to secure this system' : 'Only architects can edit a secured system'}
+              disabled={!canEditAsArchitect || !hasCompleteSite}
               style={{ textDecoration: !hasArchitect && !isOpen ? 'line-through 1px' : undefined }}
               onClick={() => {
-                props.sysView.updateOpen(!isOpen);
+                props.sysView.updateOpen(!sysMap.open);
               }}
             />
+            {!hasCompleteSite && <div style={{ color: appTheme.palette.themeTertiary, fontSize: 12 }}>
+              Complete your 1st site to secure this system
+            </div>}
           </div>
 
           <div />

--- a/src/views/SystemView2/SystemView2.tsx
+++ b/src/views/SystemView2/SystemView2.tsx
@@ -1604,7 +1604,7 @@ export class SystemView2 extends Component<SystemView2Props, SystemView2State> {
 
     const validations = [];
 
-    // archiect is unknown and there are some non-planning sites
+    // architect is unknown and there are some non-planning sites
     if (!architect && sites.some(s => s.status !== 'plan')) {
       validations.push(<div key={`valNoArchitect`}>
         » System architect unknown - <Link onClick={() => this.setState({ showEditSys: true })}>Fix it</Link>

--- a/src/views/SystemView2/SystemView2.tsx
+++ b/src/views/SystemView2/SystemView2.tsx
@@ -420,8 +420,10 @@ export class SystemView2 extends Component<SystemView2Props, SystemView2State> {
       return;
     }
 
+    const hasCompleteSite = this.state.sysMap.sites.some(s => s.status === 'complete' && s.marketId);
+
     // warn before lockout
-    const aboutToLock = !this.state.sysMap.open && !!this.state.sysMap?.architect && !isMatchingCmdr(this.state.sysMap?.architect, store.cmdrName);
+    const aboutToLock = hasCompleteSite && !this.state.sysMap.open && !!this.state.sysMap?.architect && !isMatchingCmdr(this.state.sysMap?.architect, store.cmdrName);
     if (aboutToLock && !saveName) {
       if (this.state.showConfirmAction !== this.confirmDoSaveData) {
         this.setState({
@@ -456,7 +458,9 @@ export class SystemView2 extends Component<SystemView2Props, SystemView2State> {
     if (this.state.sysOriginal.reserveLevel !== this.state.sysMap.reserveLevel) {
       payload.reserveLevel = this.state.sysMap.reserveLevel;
     }
-    if (this.state.sysOriginal.open !== this.state.sysMap.open) {
+    if (!hasCompleteSite) {
+      payload.open = true;
+    } else if (this.state.sysOriginal.open !== this.state.sysMap.open) {
       payload.open = this.state.sysMap.open;
     }
     if (this.state.sysOriginal.nickname !== this.state.sysMap.nickname) {

--- a/src/views/SystemView2/SystemView2.tsx
+++ b/src/views/SystemView2/SystemView2.tsx
@@ -264,7 +264,8 @@ export class SystemView2 extends Component<SystemView2Props, SystemView2State> {
     }
 
     const isArchitect = !!newSys.architect && isMatchingCmdr(newSys.architect, store.cmdrName);
-    const canEditAsArchitect = newSys.open || !newSys.architect || isArchitect; // || !!newSys.editors?.includes(store.cmdrName);
+    const hasCompleteSite = newSys.sites.some(s => s.status === 'complete' && s.marketId);
+    const canEditAsArchitect = newSys.open || !newSys.architect || isArchitect || !hasCompleteSite; // || !!newSys.editors?.includes(store.cmdrName);
     const lastRev = newSys.revs.reduce((m, r) => Math.max(r.rev, m), 0);
 
     this.setState({
@@ -458,9 +459,7 @@ export class SystemView2 extends Component<SystemView2Props, SystemView2State> {
     if (this.state.sysOriginal.reserveLevel !== this.state.sysMap.reserveLevel) {
       payload.reserveLevel = this.state.sysMap.reserveLevel;
     }
-    if (!hasCompleteSite) {
-      payload.open = true;
-    } else if (this.state.sysOriginal.open !== this.state.sysMap.open) {
+    if (hasCompleteSite && this.state.sysOriginal.open !== this.state.sysMap.open) {
       payload.open = this.state.sysMap.open;
     }
     if (this.state.sysOriginal.nickname !== this.state.sysMap.nickname) {


### PR DESCRIPTION
Architect can still be claimed and saved as before.

The **Secured** toggle is gated until the system page has at least one site that is both `complete` and has a `marketId`:

- **Before that:** the control shows **Secured** with a strikethrough and is disabled. Save does not send `open`. Exclusive edit is not applied yet, so others can still make changes.
- **After that:** the toggle is available and defaults to **Secured**. Save only sends `open` if the user changed it. Switching to **Open** sticks on later saves — nothing flips it back automatically.

Tooltip: *Only architects with a completed, linked site can Secure exclusive edit access*

Helper text while gated: *Complete your 1st site to secure this system*

Uses the sites already loaded on the system page — no extra API call.